### PR TITLE
Allow size string usage and make more declarative

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ const exampleClass = styled.h1`
 ```javascript
 import { setBreakPoints } from "css-in-js-media";
 setBreakPoints({ desktop: 1440, largeDesktop: 1500 });
+
+// or string size
+setBreakPoints({ desktop: '140rem', largeDesktop: 'calc(30 * 50px)' });
 ```
 
 #### get breakpoints (optional)

--- a/cssinjs-include-media.test.js
+++ b/cssinjs-include-media.test.js
@@ -71,12 +71,12 @@ describe("check if breakpoint is changed", () => {
   });
 
   describe("check if breakpoint's type is string", () => {
-    test("test for string breakpoint", () => {
+    test("test for size of string", () => {
       setBreakPoints({ largeDesktop: "150rem" });
       expect(includeMedia("<=largeDesktop")).toBe("@media (max-width: 150rem)");
     });
 
-    test("test for string breakpoint", () => {
+    test("test for size of css function usage", () => {
       setBreakPoints({ largeDesktop: "calc(20 * 18px)" });
       expect(includeMedia("<=largeDesktop")).toBe(
         "@media (max-width: calc(20 * 18px))"

--- a/cssinjs-include-media.test.js
+++ b/cssinjs-include-media.test.js
@@ -1,6 +1,6 @@
 import includeMedia, {
   setBreakPoints,
-  getBreakPoints
+  getBreakPoints,
 } from "./cssinjs-inlclude-media.js";
 
 describe("if param num is one", () => {
@@ -20,7 +20,7 @@ describe("get Breakpoints", () => {
       phone: 375,
       tablet: 768,
       desktop: 1024,
-      largeDesktop: 1440
+      largeDesktop: 1440,
     });
   });
 });
@@ -68,5 +68,19 @@ describe("check if breakpoint is changed", () => {
     expect(() => setBreakPoints({ smallDesktop: 1500 })).toThrowError(
       new Error("invalid breakpoint :(")
     );
+  });
+
+  describe("check if breakpoint's type is string", () => {
+    test("test for string breakpoint", () => {
+      setBreakPoints({ largeDesktop: "150rem" });
+      expect(includeMedia("<=largeDesktop")).toBe("@media (max-width: 150rem)");
+    });
+
+    test("test for string breakpoint", () => {
+      setBreakPoints({ largeDesktop: "calc(20 * 18px)" });
+      expect(includeMedia("<=largeDesktop")).toBe(
+        "@media (max-width: calc(20 * 18px))"
+      );
+    });
   });
 });

--- a/cssinjs-inlclude-media.js
+++ b/cssinjs-inlclude-media.js
@@ -35,10 +35,12 @@ function setBreakPoints(customizedBreakPoints) {
   breakpoints = { ...breakpoints, ...customizedBreakPoints };
 }
 
-function cssinjsMedia(query, betweenQuery) {
+function cssinjsMedia(query, betweenQuery, unit) {
   const queries = betweenQuery ? [query, betweenQuery] : [query];
   return queries.every(checkValid)
-    ? `@media ${queries.map(convertToQuery).join(" and ")}`
+    ? `@media ${queries
+        .map((query) => convertToQuery(query, unit))
+        .join(" and ")}`
     : throwError();
 }
 
@@ -54,14 +56,14 @@ function parseParam(param) {
   return [sign, screenSize];
 }
 
-function convertToQuery(param) {
-  const [sign, screenSize] = parseParam(param);
+function convertToQuery(query, unit = "px") {
+  const [sign, screenSize] = parseParam(query);
   const hasEqualSign = sign.includes("=");
   const size = hasEqualSign
     ? breakpoints[screenSize]
     : breakpoints[screenSize] - 1;
   const widthCondition = sign.includes(">") ? "min-width" : "max-width";
-  return `(${widthCondition}: ${size}px)`;
+  return `(${widthCondition}: ${size}${unit})`;
 }
 
 export default cssinjsMedia;

--- a/cssinjs-inlclude-media.js
+++ b/cssinjs-inlclude-media.js
@@ -35,12 +35,10 @@ function setBreakPoints(customizedBreakPoints) {
   breakpoints = { ...breakpoints, ...customizedBreakPoints };
 }
 
-function cssinjsMedia(query, betweenQuery, unit) {
+function cssinjsMedia(query, betweenQuery) {
   const queries = betweenQuery ? [query, betweenQuery] : [query];
   return queries.every(checkValid)
-    ? `@media ${queries
-        .map((query) => convertToQuery(query, unit))
-        .join(" and ")}`
+    ? `@media ${queries.map(convertToQuery).join(" and ")}`
     : throwError();
 }
 
@@ -56,12 +54,13 @@ function parseParam(param) {
   return [sign, screenSize];
 }
 
-function convertToQuery(param, unit = "px") {
+function convertToQuery(param) {
   const [sign, screenSize] = parseParam(param);
   const hasEqualSign = sign.includes("=");
   const size = hasEqualSign
     ? breakpoints[screenSize]
     : breakpoints[screenSize] - 1;
+  const unit = typeof size === "number" ? "px" : "";
   const widthCondition = sign.includes(">") ? "min-width" : "max-width";
   return `(${widthCondition}: ${size}${unit})`;
 }

--- a/cssinjs-inlclude-media.js
+++ b/cssinjs-inlclude-media.js
@@ -35,11 +35,10 @@ function setBreakPoints(customizedBreakPoints) {
   breakpoints = { ...breakpoints, ...customizedBreakPoints };
 }
 
-function cssinjsMedia() {
-  const validatedQuery = Array.from(arguments).filter(checkValid);
-  const isValid = Array.from(arguments).length === validatedQuery.length;
-  return isValid
-    ? "@media " + validatedQuery.map(convertToQuery).join(" and ")
+function cssinjsMedia(query, betweenQuery) {
+  const queries = betweenQuery ? [query, betweenQuery] : [query];
+  return queries.every(checkValid)
+    ? `@media ${queries.map(convertToQuery).join(" and ")}`
     : throwError();
 }
 

--- a/cssinjs-inlclude-media.js
+++ b/cssinjs-inlclude-media.js
@@ -56,8 +56,8 @@ function parseParam(param) {
   return [sign, screenSize];
 }
 
-function convertToQuery(query, unit = "px") {
-  const [sign, screenSize] = parseParam(query);
+function convertToQuery(param, unit = "px") {
+  const [sign, screenSize] = parseParam(param);
   const hasEqualSign = sign.includes("=");
   const size = hasEqualSign
     ? breakpoints[screenSize]

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,14 +12,13 @@ declare module "css-in-js-media" {
     | "largeDesktop";
 
   type BreakPoints = {
-    [key in BreakPoint]?: number;
+    [key in BreakPoint]?: number | string;
   };
 
   export function setBreakPoints(breakPoints: BreakPoints): void;
   export function getBreakPoints(): BreakPoints;
   export default function cssInJsMedia(
     firstQuery?: string,
-    secondQuery?: string,
-    unit?: string
+    secondQuery?: string
   ): string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare module "css-in-js-media" {
   export function getBreakPoints(): BreakPoints;
   export default function cssInJsMedia(
     firstQuery?: string,
-    secondQuery?: string
+    secondQuery?: string,
+    unit?: string
   ): string;
 }


### PR DESCRIPTION
승규님 안녕하세요! 오랜만이네요. 😀

## Changes
- breakpoint size의 문자열 허용 (px 이외의 단위 및 css 함수, ex. `calc()` 사용 가능)
- arguments 사용에서 명시된 인자로 수정 (breakpoint를 2개 이상 받을 경우가 없으므로 명시적으로 수정해봤습니다.)
- 유효성 검사 시 length 비교를 every 함수로 수정
```javascript
// before
const validatedQuery = Array.from(arguments).filter(checkValid);
const isValid = Array.from(arguments).length === validatedQuery.length;

// after
queries.every(checkValid);
```

---

아직 CI가 없군요..! 테스트 케이스 통과는 확인했습니다.